### PR TITLE
partial trust schema support

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -93,15 +93,16 @@ jobs:
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
 
     - name: Test
-      working-directory: ${{github.workspace}}/build/tests
-      # env:
-      #   LD_LIBRARY_PATH: /usr/local/lib:$LD_LIBRARY_PATH
-      #   CTEST_OUTPUT_ON_FAILURE: 1
+      working-directory: ${{github.workspace}}/build
+      env:
+        LD_LIBRARY_PATH: /usr/local/lib:$LD_LIBRARY_PATH
+        CTEST_OUTPUT_ON_FAILURE: 1
       # Execute tests defined by the CMake configuration.
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
       run: |
-        cp ../../tests/unit-tests/trust-schema.conf trust-schema.conf
-        ./unit-tests
+        cp ../tests/unit-tests/trust-schema.conf trust-schema.conf
+        ./tests/unit-tests
+        bash ./../examples/run-examples.sh .
   
   macos-build:
     name: Xcode ${{ matrix.xcode }} on ${{ matrix.os }}
@@ -209,12 +210,13 @@ jobs:
         run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
 
       - name: Test
-        working-directory: ${{github.workspace}}/build/tests
-        # env:
-        #   LD_LIBRARY_PATH: /usr/local/lib:$LD_LIBRARY_PATH
-        #   CTEST_OUTPUT_ON_FAILURE: 1
-        # # Execute tests defined by the CMake configuration.
-        # # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
+        working-directory: ${{github.workspace}}/build
+        env:
+          LD_LIBRARY_PATH: /usr/local/lib:$LD_LIBRARY_PATH
+          CTEST_OUTPUT_ON_FAILURE: 1
+        # Execute tests defined by the CMake configuration.
+        # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
         run: |
-          cp ../../tests/unit-tests/trust-schema.conf trust-schema.conf
-          ./unit-tests
+          cp ../tests/unit-tests/trust-schema.conf trust-schema.conf
+          ./tests/unit-tests
+          bash ./../examples/run-examples.sh .

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -94,13 +94,15 @@ jobs:
 
     - name: Test
       working-directory: ${{github.workspace}}/build/tests
-      env:
-        LD_LIBRARY_PATH: /usr/local/lib:$LD_LIBRARY_PATH
-        CTEST_OUTPUT_ON_FAILURE: 1
+      # env:
+      #   LD_LIBRARY_PATH: /usr/local/lib:$LD_LIBRARY_PATH
+      #   CTEST_OUTPUT_ON_FAILURE: 1
       # Execute tests defined by the CMake configuration.
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: ctest
-
+      run: |
+        cp ../../tests/unit-tests/trust-schema.conf trust-schema.conf
+        ./unit-tests
+  
   macos-build:
     name: Xcode ${{ matrix.xcode }} on ${{ matrix.os }}
     strategy:
@@ -208,9 +210,11 @@ jobs:
 
       - name: Test
         working-directory: ${{github.workspace}}/build/tests
-        env:
-          LD_LIBRARY_PATH: /usr/local/lib:$LD_LIBRARY_PATH
-          CTEST_OUTPUT_ON_FAILURE: 1
-        # Execute tests defined by the CMake configuration.
-        # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-        run: ctest
+        # env:
+        #   LD_LIBRARY_PATH: /usr/local/lib:$LD_LIBRARY_PATH
+        #   CTEST_OUTPUT_ON_FAILURE: 1
+        # # Execute tests defined by the CMake configuration.
+        # # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
+        run: |
+          cp ../../tests/unit-tests/trust-schema.conf trust-schema.conf
+          ./unit-tests

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ __pycache__/
 # Other
 .idea/
 cmake-build-*/
+
+# Example files
+*.cert

--- a/examples/kp-consumer-example.cpp
+++ b/examples/kp-consumer-example.cpp
@@ -32,11 +32,12 @@ class Consumer
 {
 public:
   Consumer()
-    : m_producerCert(m_keyChain.getPib().getIdentity("/producerPrefix").getDefaultKey().getDefaultCertificate())
-    , m_consumerCert(m_keyChain.getPib().getIdentity("/consumerPrefix1").getDefaultKey().getDefaultCertificate())
-    , m_consumer(m_face, m_keyChain, m_consumerCert,
-                 m_keyChain.getPib().getIdentity("/aaPrefix").getDefaultKey().getDefaultCertificate())
+    : m_producerCert(m_keyChain.getPib().getIdentity("/example/producer").getDefaultKey().getDefaultCertificate())
+    , m_consumerCert(m_keyChain.getPib().getIdentity("/example/consumer").getDefaultKey().getDefaultCertificate())
+    , m_consumer(m_face, m_keyChain, m_validator, m_consumerCert,
+                 m_keyChain.getPib().getIdentity("/example/aa").getDefaultKey().getDefaultCertificate())
   {
+    m_validator.load("trust-schema.conf");
     m_consumer.obtainDecryptionKey();
   }
 
@@ -63,6 +64,7 @@ public:
 private:
   ndn::Face m_face;
   ndn::KeyChain m_keyChain;
+  ndn::ValidatorConfig m_validator{m_face};
   ndn::security::Certificate m_producerCert;
   ndn::security::Certificate m_consumerCert;
   ndn::nacabe::Consumer m_consumer;

--- a/examples/run-examples.sh
+++ b/examples/run-examples.sh
@@ -4,17 +4,25 @@
 # If you would like to try on a normal user account, make sure that identity /consumerPrefix1, /aaPrefix, /producerPrefix
 # are not used, as these keys will be deleted.
 
-if ndnsec list | grep "/consumerPrefix1\|/aaPrefix\|/producerPrefix"
+if ndnsec list | grep "/example/consumer\|/example/aa\|/example/producer"
 then
-  echo "Make sure you so not have identity /consumerPrefix1, /aaPrefix, /producerPrefix in the keychain before try again"
+  echo "Make sure you do not have identity /example/consumer, /example/aa, /example/producer in the keychain before try again"
   exit 1
 fi
 
 export NDN_LOG=*=INFO
 
-ndnsec key-gen -t r /consumerPrefix1
-ndnsec key-gen /aaPrefix
-ndnsec key-gen /producerPrefix
+ndnsec key-gen /example > /dev/null
+ndnsec cert-dump -i /example > example-trust-anchor.cert
+
+ndnsec key-gen /example/aa > /dev/null
+ndnsec sign-req /example/aa | ndnsec cert-gen -s /example -i example | ndnsec cert-install -
+
+ndnsec key-gen /example/producer > /dev/null
+ndnsec sign-req /example/producer | ndnsec cert-gen -s /example -i example | ndnsec cert-install -
+
+ndnsec key-gen -t r /example/consumer > /dev/null
+ndnsec sign-req /example/consumer | ndnsec cert-gen -s /example -i example | ndnsec cert-install -
 
 $1/examples/kp-aa-example &
 aa_pid=$!
@@ -29,8 +37,8 @@ exit_val=$?
 kill $aa_pid
 kill $pro_pid
 
-ndnsec delete /consumerPrefix1
-ndnsec delete /aaPrefix
-ndnsec delete /producerPrefix
+ndnsec delete /example/consumer
+ndnsec delete /example/aa
+ndnsec delete /example/producer
 
 exit $exit_val

--- a/examples/trust-schema.conf
+++ b/examples/trust-schema.conf
@@ -1,0 +1,34 @@
+rule
+{
+  id "rule"
+  for data
+  filter
+  {
+    type name
+    name /example
+    relation is-prefix-of
+  }
+  checker
+  {
+    type customized
+    sig-type ecdsa-sha256
+    key-locator
+    {
+      type name
+      hyper-relation
+      {
+        k-regex ^(<>*)<KEY><><>?<>?$
+        k-expand \\1
+        h-relation is-prefix-of
+        p-regex ^(<>*)<>*$
+        p-expand \\1
+      }
+    }
+  }
+}
+
+trust-anchor
+{
+  type file
+  file-name "example-trust-anchor.cert"
+}

--- a/src/attribute-authority.cpp
+++ b/src/attribute-authority.cpp
@@ -117,7 +117,6 @@ AttributeAuthority::onPublicParamsRequest(const Interest& interest)
   result.setFreshnessPeriod(5_s);
   const auto& contentBuf = m_pubParams.toBuffer();
   result.setContent(contentBuf);
-  NDN_LOG_DEBUG("before sign");
   m_keyChain.sign(result, signingByCertificate(m_cert));
 
   NDN_LOG_TRACE("Reply public params request.");

--- a/src/common.hpp
+++ b/src/common.hpp
@@ -57,6 +57,7 @@
 #include <ndn-cxx/security/certificate.hpp>
 #include <ndn-cxx/security/key-chain.hpp>
 #include <ndn-cxx/security/validator.hpp>
+#include <ndn-cxx/security/validator-config.hpp>
 #include <ndn-cxx/util/logger.hpp>
 #include <ndn-cxx/util/span.hpp>
 

--- a/src/consumer.hpp
+++ b/src/consumer.hpp
@@ -21,6 +21,7 @@
 #ifndef NAC_ABE_CONSUMER_HPP
 #define NAC_ABE_CONSUMER_HPP
 
+#include "common.hpp"
 #include "trust-config.hpp"
 #include "algo/public-params.hpp"
 #include "algo/private-key.hpp"
@@ -39,6 +40,7 @@ public:
 
 public:
   Consumer(Face& face, KeyChain& keyChain,
+           security::Validator& validator,
            const security::Certificate& identityCert,
            const security::Certificate& attrAuthorityCertificate,
            Interest publicParamInterestTemplate = ParamFetcher::getDefaultInterestTemplate());
@@ -109,6 +111,7 @@ private:
   Face& m_face;
   KeyChain& m_keyChain;
   Name m_attrAuthorityPrefix;
+  security::Validator& m_validator;
 
   TrustConfig m_trustConfig;
   algo::PrivateKey m_keyCache;

--- a/src/param-fetcher.hpp
+++ b/src/param-fetcher.hpp
@@ -21,6 +21,7 @@
 #ifndef NAC_ABE_PARAM_FETCHER_HPP
 #define NAC_ABE_PARAM_FETCHER_HPP
 
+#include "common.hpp"
 #include "algo/public-params.hpp"
 #include "trust-config.hpp"
 
@@ -33,7 +34,8 @@ namespace nacabe {
 class ParamFetcher
 {
 public:
-  ParamFetcher(Face& face, const Name& attrAuthorityPrefix, const TrustConfig& trustConfig,
+  ParamFetcher(Face& face, security::Validator& validator,
+               const Name& attrAuthorityPrefix, const TrustConfig& trustConfig,
                Interest interestTemplate = getDefaultInterestTemplate());
 
   void
@@ -65,6 +67,7 @@ private:
 
 private:
   Face& m_face;
+  security::Validator& m_validator;
   const Name& m_attrAuthorityPrefix;
   const TrustConfig& m_trustConfig;
 

--- a/src/producer.cpp
+++ b/src/producer.cpp
@@ -34,26 +34,29 @@ namespace nacabe {
 NDN_LOG_INIT(nacabe.Producer);
 
 Producer::Producer(Face& face, KeyChain& keyChain,
+                   security::Validator& validator,
                    const security::Certificate& identityCert,
                    const security::Certificate& attrAuthorityCertificate,
                    Interest publicParamInterestTemplate)
   : m_cert(identityCert)
   , m_face(face)
+  , m_validator(validator)
   , m_keyChain(keyChain)
   , m_attrAuthorityPrefix(attrAuthorityCertificate.getIdentity())
-  , m_paramFetcher(m_face, m_attrAuthorityPrefix, m_trustConfig, publicParamInterestTemplate)
+  , m_paramFetcher(m_face, validator, m_attrAuthorityPrefix, m_trustConfig, publicParamInterestTemplate)
 {
   m_trustConfig.addOrUpdateCertificate(attrAuthorityCertificate);
   m_paramFetcher.fetchPublicParams();
   replyTemplate.setFreshnessPeriod(5_s);
 }
 
-Producer::Producer(Face& face, KeyChain& keyChain,
+Producer::Producer(Face& face, KeyChain& keyChain, 
+                   security::Validator& m_validator,
                    const security::Certificate& identityCert,
                    const security::Certificate& attrAuthorityCertificate,
                    const security::Certificate& dataOwnerCertificate,
                    Interest publicParamInterestTemplate)
-  : Producer(face, keyChain, identityCert, attrAuthorityCertificate, publicParamInterestTemplate)
+  : Producer(face, keyChain, m_validator, identityCert, attrAuthorityCertificate, publicParamInterestTemplate)
 {
   m_dataOwnerPrefix = dataOwnerCertificate.getIdentity();
   m_trustConfig.addOrUpdateCertificate(dataOwnerCertificate);

--- a/src/producer.hpp
+++ b/src/producer.hpp
@@ -44,6 +44,7 @@ public:
    * @brief Initialize a producer. Use when no data owner defined.
    */
   Producer(Face& face, KeyChain& keyChain,
+           security::Validator& validator,
            const security::Certificate& identityCert,
            const security::Certificate& attrAuthorityCertificate,
            Interest publicParamInterestTemplate = ParamFetcher::getDefaultInterestTemplate());
@@ -52,6 +53,7 @@ public:
    * @brief Initialize a producer. Use when a data owner is defined.
    */
   Producer(Face& face, KeyChain& keyChain,
+           security::Validator& validator,
            const security::Certificate& identityCert,
            const security::Certificate& attrAuthorityCertificate,
            const security::Certificate& dataOwnerCertificate,
@@ -184,6 +186,7 @@ private:
   security::Certificate m_cert;
   Face& m_face;
   KeyChain& m_keyChain;
+  security::Validator& m_validator;
   Name m_attrAuthorityPrefix;
   Name m_dataOwnerPrefix;
   TrustConfig m_trustConfig;

--- a/tests/unit-tests/attribute-authority.t.cpp
+++ b/tests/unit-tests/attribute-authority.t.cpp
@@ -34,13 +34,21 @@ class TestAttributeAuthorityFixture : public IdentityManagementTimeFixture
 {
 public:
   TestAttributeAuthorityFixture()
-    : attrAuthorityPrefix("/authority")
+    : anchorPrefix("/example")
+    , attrAuthorityPrefix("/example/aa")
   {
-    consumerCert = addIdentity("/consumer", RsaKeyParams()).getDefaultKey().getDefaultCertificate();
-    authorityCert = addIdentity("/authority").getDefaultKey().getDefaultCertificate();
+    security::pib::Identity anchorId = addIdentity("/example");
+    security::pib::Identity consumerId = addIdentity("/example/consumer", RsaKeyParams());
+    addSubCertificate("/example/consumer", anchorId);
+    consumerCert = consumerId.getDefaultKey().getDefaultCertificate();
+
+    security::pib::Identity authorityId = addIdentity(attrAuthorityPrefix);
+    addSubCertificate(attrAuthorityPrefix, anchorId);
+    authorityCert = authorityId.getDefaultKey().getDefaultCertificate();
   }
 
 protected:
+  Name anchorPrefix;
   Name attrAuthorityPrefix;
   security::Certificate consumerCert;
   security::Certificate authorityCert;
@@ -90,7 +98,6 @@ BOOST_AUTO_TEST_CASE(OnPublicParams)
 
 BOOST_AUTO_TEST_CASE(OnPrvKey)
 {
-  Name consumerName("/consumer");
   std::list<std::string> attrList = {"attr1", "attr2", "attr3", "attr4", "attr5",
                                      "attr6", "attr7", "attr8", "attr9", "attr10"};
 
@@ -127,7 +134,6 @@ BOOST_AUTO_TEST_CASE(OnPrvKey)
 
 BOOST_AUTO_TEST_CASE(OnKpPrvKey)
 {
-  Name consumerName("/consumer");
   Policy policy = "(a or b) and (c or d)";
 
   util::DummyClientFace face(io, {true, true});

--- a/tests/unit-tests/consumer.t.cpp
+++ b/tests/unit-tests/consumer.t.cpp
@@ -38,7 +38,7 @@ public:
   {
     c1.linkTo(c2);
     security::pib::Identity anchorId = addIdentity("/example");
-    saveCertToFile(anchorCert, "tests/unit-tests/example-trust-anchor.t.cert");
+    saveCertToFile(anchorCert, "example-trust-anchor.cert");
     security::pib::Identity consumerId = addIdentity("/example/consumer", RsaKeyParams());
     addSubCertificate("/example/consumer", anchorId);
     consumerCert = consumerId.getDefaultKey().getDefaultCertificate();
@@ -68,7 +68,7 @@ BOOST_AUTO_TEST_CASE(Constructor)
   advanceClocks(time::milliseconds(20), 60);
 
   security::ValidatorConfig validator(c1);
-  validator.load("tests/unit-tests/trust-schema.t.conf");
+  validator.load("trust-schema.conf");
   Consumer consumer(c1, m_keyChain, validator, consumerCert, authorityCert);
   advanceClocks(time::milliseconds(20), 60);
 

--- a/tests/unit-tests/integrated-test.t.cpp
+++ b/tests/unit-tests/integrated-test.t.cpp
@@ -55,7 +55,7 @@ public:
 
     security::pib::Identity anchorId = addIdentity("/example");
     anchorCert = anchorId.getDefaultKey().getDefaultCertificate();
-    saveCertToFile(anchorCert, "tests/unit-tests/example-trust-anchor.t.cert");
+    saveCertToFile(anchorCert, "example-trust-anchor.cert");
     security::pib::Identity consumerId1 = addIdentity("/example/consumer1", RsaKeyParams());
     addSubCertificate("/example/consumer1", anchorId);
     consumerCert1 = consumerId1.getDefaultKey().getDefaultCertificate();
@@ -124,7 +124,7 @@ BOOST_AUTO_TEST_CASE(Cp)
   // set up consumer
   NDN_LOG_INFO("Create Consumer 1. Consumer 1 prefix:"<<consumerCert1.getIdentity());
   security::ValidatorConfig validator1(consumerFace1);
-  validator1.load("tests/unit-tests/trust-schema.t.conf");
+  validator1.load("trust-schema.conf");
   Consumer consumer1(consumerFace1, m_keyChain, validator1, consumerCert1, aaCert);
   advanceClocks(time::milliseconds(20), 60);
   consumerFace1.receive(aaCert);
@@ -136,7 +136,7 @@ BOOST_AUTO_TEST_CASE(Cp)
   // set up consumer
   NDN_LOG_INFO("Create Consumer 2. Consumer 2 prefix:"<<consumerCert2.getIdentity());
   security::ValidatorConfig validator2(consumerFace2);
-  validator2.load("tests/unit-tests/trust-schema.t.conf");
+  validator2.load("trust-schema.conf");
   Consumer consumer2(consumerFace2, m_keyChain, validator2, consumerCert2, aaCert);
   advanceClocks(time::milliseconds(20), 60);
   consumerFace2.receive(aaCert);
@@ -148,7 +148,7 @@ BOOST_AUTO_TEST_CASE(Cp)
   // set up producer
   NDN_LOG_INFO("Create Producer. Producer prefix:"<<producerCert.getIdentity());
   security::ValidatorConfig validator3(producerFace);
-  validator3.load("tests/unit-tests/trust-schema.t.conf");
+  validator3.load("trust-schema.conf");
   Producer producer(producerFace, m_keyChain, validator3, producerCert, aaCert, dataOwnerCert);
   advanceClocks(time::milliseconds(20), 60);
   producerFace.receive(aaCert);
@@ -273,7 +273,7 @@ BOOST_AUTO_TEST_CASE(Kp)
   // set up consumer
   NDN_LOG_INFO("Create Consumer 1. Consumer 1 prefix:"<<consumerCert1.getIdentity());
   security::ValidatorConfig validator1(consumerFace1);
-  validator1.load("tests/unit-tests/trust-schema.t.conf");
+  validator1.load("trust-schema.conf");
   Consumer consumer1(consumerFace1, m_keyChain, validator1, consumerCert1, aaCert);
   advanceClocks(time::milliseconds(20), 60);
   consumerFace1.receive(aaCert);
@@ -285,7 +285,7 @@ BOOST_AUTO_TEST_CASE(Kp)
   // set up consumer
   NDN_LOG_INFO("Create Consumer 2. Consumer 2 prefix:"<<consumerCert2.getIdentity());
   security::ValidatorConfig validator2(consumerFace2);
-  validator2.load("tests/unit-tests/trust-schema.t.conf");
+  validator2.load("trust-schema.conf");
   Consumer consumer2(consumerFace2, m_keyChain, validator2, consumerCert2, aaCert);
   advanceClocks(time::milliseconds(20), 60);
   consumerFace2.receive(aaCert);
@@ -297,7 +297,7 @@ BOOST_AUTO_TEST_CASE(Kp)
   // set up producer
   NDN_LOG_INFO("Create Producer. Producer prefix:"<<producerCert.getIdentity());
   security::ValidatorConfig validator3(producerFace);
-  validator3.load("tests/unit-tests/trust-schema.t.conf");
+  validator3.load("trust-schema.conf");
   Producer producer(producerFace, m_keyChain, validator3, producerCert, aaCert, dataOwnerCert);
   advanceClocks(time::milliseconds(20), 60);
   producerFace.receive(aaCert);
@@ -420,7 +420,7 @@ BOOST_AUTO_TEST_CASE(KpCache)
   // set up consumer
   NDN_LOG_INFO("Create Consumer 1. Consumer 1 prefix:"<<consumerCert1.getIdentity());
   security::ValidatorConfig validator1(consumerFace1);
-  validator1.load("tests/unit-tests/trust-schema.t.conf");
+  validator1.load("trust-schema.conf");
   Consumer consumer1(consumerFace1, m_keyChain, validator1, consumerCert1, aaCert);
   advanceClocks(time::milliseconds(20), 60);
   consumerFace1.receive(aaCert);
@@ -431,7 +431,7 @@ BOOST_AUTO_TEST_CASE(KpCache)
   // set up consumer
   NDN_LOG_INFO("Create Consumer 2. Consumer 2 prefix:"<<consumerCert2.getIdentity());
   security::ValidatorConfig validator2(consumerFace2);
-  validator2.load("tests/unit-tests/trust-schema.t.conf");
+  validator2.load("trust-schema.conf");
   Consumer consumer2(consumerFace2, m_keyChain, validator2, consumerCert2, aaCert);
   advanceClocks(time::milliseconds(20), 60);
   consumerFace2.receive(aaCert);
@@ -442,7 +442,7 @@ BOOST_AUTO_TEST_CASE(KpCache)
   // set up producer
   NDN_LOG_INFO("Create Producer. Producer prefix:"<<producerCert.getIdentity());
   security::ValidatorConfig validator3(producerFace);
-  validator3.load("tests/unit-tests/trust-schema.t.conf");
+  validator3.load("trust-schema.conf");
   CacheProducer producer(producerFace, m_keyChain, validator3, producerCert, aaCert, dataOwnerCert);
   advanceClocks(time::milliseconds(20), 60);
   producerFace.receive(aaCert);

--- a/tests/unit-tests/integrated-test.t.cpp
+++ b/tests/unit-tests/integrated-test.t.cpp
@@ -53,12 +53,32 @@ public:
     producerFace.linkTo(consumerFace2);
     producerFace.linkTo(dataOwnerFace);
 
-    aaCert = addIdentity("/aaPrefix").getDefaultKey().getDefaultCertificate();
-    tokenIssuerCert = addIdentity("/tokenIssuerPrefix").getDefaultKey().getDefaultCertificate();
-    consumerCert1 = addIdentity("/consumerPrefix1", RsaKeyParams()).getDefaultKey().getDefaultCertificate();
-    consumerCert2 = addIdentity("/consumerPrefix2", RsaKeyParams()).getDefaultKey().getDefaultCertificate();
-    producerCert = addIdentity("/producerPrefix").getDefaultKey().getDefaultCertificate();
-    dataOwnerCert = addIdentity("/dataOwnerPrefix").getDefaultKey().getDefaultCertificate();
+    security::pib::Identity anchorId = addIdentity("/example");
+    anchorCert = anchorId.getDefaultKey().getDefaultCertificate();
+    saveCertToFile(anchorCert, "tests/unit-tests/example-trust-anchor.t.cert");
+    security::pib::Identity consumerId1 = addIdentity("/example/consumer1", RsaKeyParams());
+    addSubCertificate("/example/consumer1", anchorId);
+    consumerCert1 = consumerId1.getDefaultKey().getDefaultCertificate();
+
+    security::pib::Identity consumerId2 = addIdentity("/example/consumer2", RsaKeyParams());
+    addSubCertificate("/example/consumer1", anchorId);
+    consumerCert2 = consumerId2.getDefaultKey().getDefaultCertificate();
+
+    security::pib::Identity producerId = addIdentity("/example/producer");
+    addSubCertificate("/example/producer", anchorId);
+    producerCert = producerId.getDefaultKey().getDefaultCertificate();
+
+    security::pib::Identity dataOwnerId = addIdentity("/example/dataOwner");
+    addSubCertificate("/example/dataOwner", anchorId);
+    dataOwnerCert = dataOwnerId.getDefaultKey().getDefaultCertificate();
+
+    security::pib::Identity tokenIssuerId = addIdentity("/example/tokenIssuer");
+    addSubCertificate("/example/tokenIssuer", anchorId);
+    tokenIssuerCert = tokenIssuerId.getDefaultKey().getDefaultCertificate();
+
+    security::pib::Identity authorityId = addIdentity("/example/authority");
+    addSubCertificate("/example/authority", anchorId);
+    aaCert = authorityId.getDefaultKey().getDefaultCertificate();
 
     signingInfo = signingByCertificate(producerCert);
   }
@@ -72,6 +92,7 @@ protected:
   util::DummyClientFace dataOwnerFace;
 
   security::Certificate aaCert;
+  security::Certificate anchorCert;
   security::Certificate tokenIssuerCert;
   security::Certificate consumerCert1;
   security::Certificate consumerCert2;
@@ -102,19 +123,37 @@ BOOST_AUTO_TEST_CASE(Cp)
 
   // set up consumer
   NDN_LOG_INFO("Create Consumer 1. Consumer 1 prefix:"<<consumerCert1.getIdentity());
-  Consumer consumer1(consumerFace1, m_keyChain, consumerCert1, aaCert);
+  security::ValidatorConfig validator1(consumerFace1);
+  validator1.load("tests/unit-tests/trust-schema.t.conf");
+  Consumer consumer1(consumerFace1, m_keyChain, validator1, consumerCert1, aaCert);
+  advanceClocks(time::milliseconds(20), 60);
+  consumerFace1.receive(aaCert);
+  advanceClocks(time::milliseconds(20), 60);
+  consumerFace1.receive(anchorCert);
   advanceClocks(time::milliseconds(20), 60);
   BOOST_CHECK(consumer1.m_paramFetcher.getPublicParams().m_pub != "");
 
   // set up consumer
   NDN_LOG_INFO("Create Consumer 2. Consumer 2 prefix:"<<consumerCert2.getIdentity());
-  Consumer consumer2(consumerFace2, m_keyChain, consumerCert2, aaCert);
+  security::ValidatorConfig validator2(consumerFace2);
+  validator2.load("tests/unit-tests/trust-schema.t.conf");
+  Consumer consumer2(consumerFace2, m_keyChain, validator2, consumerCert2, aaCert);
+  advanceClocks(time::milliseconds(20), 60);
+  consumerFace2.receive(aaCert);
+  advanceClocks(time::milliseconds(20), 60);
+  consumerFace2.receive(anchorCert);
   advanceClocks(time::milliseconds(20), 60);
   BOOST_CHECK(consumer2.m_paramFetcher.getPublicParams().m_pub != "");
 
   // set up producer
   NDN_LOG_INFO("Create Producer. Producer prefix:"<<producerCert.getIdentity());
-  Producer producer(producerFace, m_keyChain, producerCert, aaCert, dataOwnerCert);
+  security::ValidatorConfig validator3(producerFace);
+  validator3.load("tests/unit-tests/trust-schema.t.conf");
+  Producer producer(producerFace, m_keyChain, validator3, producerCert, aaCert, dataOwnerCert);
+  advanceClocks(time::milliseconds(20), 60);
+  producerFace.receive(aaCert);
+  advanceClocks(time::milliseconds(20), 60);
+  producerFace.receive(anchorCert);
   advanceClocks(time::milliseconds(20), 60);
   BOOST_CHECK(producer.m_paramFetcher.getPublicParams().m_pub != "");
 
@@ -180,6 +219,14 @@ BOOST_AUTO_TEST_CASE(Cp)
     }
   );
   advanceClocks(time::milliseconds(20), 60);
+  consumerFace1.receive(producerCert);
+  advanceClocks(time::milliseconds(20), 60);
+  consumerFace1.receive(anchorCert);
+  advanceClocks(time::milliseconds(20), 60);
+  consumerFace1.receive(aaCert);
+  advanceClocks(time::milliseconds(20), 60);
+  consumerFace1.receive(anchorCert);
+  advanceClocks(time::milliseconds(20), 60);
   BOOST_CHECK(isConsumeCbCalled);
 
   isConsumeCbCalled = false;
@@ -193,6 +240,14 @@ BOOST_AUTO_TEST_CASE(Cp)
       isConsumeCbCalled = true;
     }
   );
+  advanceClocks(time::milliseconds(20), 60);
+  consumerFace2.receive(producerCert);
+  advanceClocks(time::milliseconds(20), 60);
+  consumerFace2.receive(anchorCert);
+  advanceClocks(time::milliseconds(20), 60);
+  consumerFace2.receive(aaCert);
+  advanceClocks(time::milliseconds(20), 60);
+  consumerFace2.receive(anchorCert);
   advanceClocks(time::milliseconds(20), 60);
   BOOST_CHECK(isConsumeCbCalled);
 }
@@ -217,19 +272,37 @@ BOOST_AUTO_TEST_CASE(Kp)
 
   // set up consumer
   NDN_LOG_INFO("Create Consumer 1. Consumer 1 prefix:"<<consumerCert1.getIdentity());
-  Consumer consumer1(consumerFace1, m_keyChain, consumerCert1, aaCert);
+  security::ValidatorConfig validator1(consumerFace1);
+  validator1.load("tests/unit-tests/trust-schema.t.conf");
+  Consumer consumer1(consumerFace1, m_keyChain, validator1, consumerCert1, aaCert);
+  advanceClocks(time::milliseconds(20), 60);
+  consumerFace1.receive(aaCert);
+  advanceClocks(time::milliseconds(20), 60);
+  consumerFace1.receive(anchorCert);
   advanceClocks(time::milliseconds(20), 60);
   BOOST_CHECK(consumer1.m_paramFetcher.getPublicParams().m_pub != "");
 
   // set up consumer
   NDN_LOG_INFO("Create Consumer 2. Consumer 2 prefix:"<<consumerCert2.getIdentity());
-  Consumer consumer2(consumerFace2, m_keyChain, consumerCert2, aaCert);
+  security::ValidatorConfig validator2(consumerFace2);
+  validator2.load("tests/unit-tests/trust-schema.t.conf");
+  Consumer consumer2(consumerFace2, m_keyChain, validator2, consumerCert2, aaCert);
+  advanceClocks(time::milliseconds(20), 60);
+  consumerFace2.receive(aaCert);
+  advanceClocks(time::milliseconds(20), 60);
+  consumerFace2.receive(anchorCert);
   advanceClocks(time::milliseconds(20), 60);
   BOOST_CHECK(consumer2.m_paramFetcher.getPublicParams().m_pub != "");
 
   // set up producer
   NDN_LOG_INFO("Create Producer. Producer prefix:"<<producerCert.getIdentity());
-  Producer producer(producerFace, m_keyChain, producerCert, aaCert, dataOwnerCert);
+  security::ValidatorConfig validator3(producerFace);
+  validator3.load("tests/unit-tests/trust-schema.t.conf");
+  Producer producer(producerFace, m_keyChain, validator3, producerCert, aaCert, dataOwnerCert);
+  advanceClocks(time::milliseconds(20), 60);
+  producerFace.receive(aaCert);
+  advanceClocks(time::milliseconds(20), 60);
+  producerFace.receive(anchorCert);
   advanceClocks(time::milliseconds(20), 60);
   BOOST_CHECK(producer.m_paramFetcher.getPublicParams().m_pub != "");
 
@@ -293,6 +366,14 @@ BOOST_AUTO_TEST_CASE(Kp)
                     }
   );
   advanceClocks(time::milliseconds(20), 60);
+  consumerFace1.receive(producerCert);
+  advanceClocks(time::milliseconds(20), 60);
+  consumerFace1.receive(anchorCert);
+  advanceClocks(time::milliseconds(20), 60);
+  consumerFace1.receive(aaCert);
+  advanceClocks(time::milliseconds(20), 60);
+  consumerFace1.receive(anchorCert);
+  advanceClocks(time::milliseconds(20), 60);
   BOOST_CHECK(isConsumeCbCalled);
 
   isConsumeCbCalled = false;
@@ -306,6 +387,14 @@ BOOST_AUTO_TEST_CASE(Kp)
                       isConsumeCbCalled = true;
                     }
   );
+  advanceClocks(time::milliseconds(20), 60);
+  consumerFace2.receive(producerCert);
+  advanceClocks(time::milliseconds(20), 60);
+  consumerFace2.receive(anchorCert);
+  advanceClocks(time::milliseconds(20), 60);
+  consumerFace2.receive(aaCert);
+  advanceClocks(time::milliseconds(20), 60);
+  consumerFace2.receive(anchorCert);
   advanceClocks(time::milliseconds(20), 60);
   BOOST_CHECK(isConsumeCbCalled);
 }
@@ -330,20 +419,35 @@ BOOST_AUTO_TEST_CASE(KpCache)
 
   // set up consumer
   NDN_LOG_INFO("Create Consumer 1. Consumer 1 prefix:"<<consumerCert1.getIdentity());
-  Consumer consumer1(consumerFace1, m_keyChain, consumerCert1, aaCert);
+  security::ValidatorConfig validator1(consumerFace1);
+  validator1.load("tests/unit-tests/trust-schema.t.conf");
+  Consumer consumer1(consumerFace1, m_keyChain, validator1, consumerCert1, aaCert);
   advanceClocks(time::milliseconds(20), 60);
+  consumerFace1.receive(aaCert);
+  advanceClocks(time::milliseconds(20), 60);
+  consumerFace1.receive(anchorCert);
   BOOST_CHECK(consumer1.m_paramFetcher.getPublicParams().m_pub != "");
 
   // set up consumer
   NDN_LOG_INFO("Create Consumer 2. Consumer 2 prefix:"<<consumerCert2.getIdentity());
-  Consumer consumer2(consumerFace2, m_keyChain, consumerCert2, aaCert);
+  security::ValidatorConfig validator2(consumerFace2);
+  validator2.load("tests/unit-tests/trust-schema.t.conf");
+  Consumer consumer2(consumerFace2, m_keyChain, validator2, consumerCert2, aaCert);
   advanceClocks(time::milliseconds(20), 60);
+  consumerFace2.receive(aaCert);
+  advanceClocks(time::milliseconds(20), 60);
+  consumerFace2.receive(anchorCert);
   BOOST_CHECK(consumer2.m_paramFetcher.getPublicParams().m_pub != "");
 
   // set up producer
   NDN_LOG_INFO("Create Producer. Producer prefix:"<<producerCert.getIdentity());
-  CacheProducer producer(producerFace, m_keyChain, producerCert, aaCert, dataOwnerCert);
+  security::ValidatorConfig validator3(producerFace);
+  validator3.load("tests/unit-tests/trust-schema.t.conf");
+  CacheProducer producer(producerFace, m_keyChain, validator3, producerCert, aaCert, dataOwnerCert);
   advanceClocks(time::milliseconds(20), 60);
+  producerFace.receive(aaCert);
+  advanceClocks(time::milliseconds(20), 60);
+  producerFace.receive(anchorCert);
   BOOST_CHECK(producer.m_paramFetcher.getPublicParams().m_pub != "");
 
   // set up data owner
@@ -409,6 +513,14 @@ BOOST_AUTO_TEST_CASE(KpCache)
                     }
   );
   advanceClocks(time::milliseconds(20), 60);
+  consumerFace1.receive(producerCert);
+  advanceClocks(time::milliseconds(20), 60);
+  consumerFace1.receive(anchorCert);
+  advanceClocks(time::milliseconds(20), 60);
+  consumerFace1.receive(aaCert);
+  advanceClocks(time::milliseconds(20), 60);
+  consumerFace1.receive(anchorCert);
+  advanceClocks(time::milliseconds(20), 60);
   BOOST_CHECK(isConsumeCbCalled);
 
   isConsumeCbCalled = false;
@@ -422,6 +534,14 @@ BOOST_AUTO_TEST_CASE(KpCache)
                       isConsumeCbCalled = true;
                     }
   );
+  advanceClocks(time::milliseconds(20), 60);
+  consumerFace2.receive(producerCert);
+  advanceClocks(time::milliseconds(20), 60);
+  consumerFace2.receive(anchorCert);
+  advanceClocks(time::milliseconds(20), 60);
+  consumerFace2.receive(aaCert);
+  advanceClocks(time::milliseconds(20), 60);
+  consumerFace2.receive(anchorCert);
   advanceClocks(time::milliseconds(20), 60);
   BOOST_CHECK(isConsumeCbCalled);
 }

--- a/tests/unit-tests/param-fetcher.t.cpp
+++ b/tests/unit-tests/param-fetcher.t.cpp
@@ -39,11 +39,18 @@ public:
   TestParamFetcherFixture()
     : c1(io, m_keyChain, {true, true})
     , c2(io, m_keyChain, {true, true})
-    , attrAuthorityPrefix("/authority")
+    , attrAuthorityPrefix("/example/authority")
   {
     c1.linkTo(c2);
-    authorityCert = addIdentity("/authority").getDefaultKey().getDefaultCertificate();
-    trustConfig.addOrUpdateCertificate(authorityCert);
+
+    security::pib::Identity anchorId = addIdentity("/example");
+    anchorCert = anchorId.getDefaultKey().getDefaultCertificate();
+    saveCertToFile(anchorCert, "tests/unit-tests/example-trust-anchor.t.cert");
+    security::pib::Identity authorityId = addIdentity(attrAuthorityPrefix);
+    addSubCertificate(attrAuthorityPrefix, anchorId);
+    authorityCert = authorityId.getDefaultKey().getDefaultCertificate();
+    
+    trustConfig.addOrUpdateCertificate(security::Certificate(authorityCert));
   }
 
 protected:
@@ -51,6 +58,7 @@ protected:
   util::DummyClientFace c2;
   Name attrAuthorityPrefix;
   security::Certificate authorityCert;
+  security::Certificate anchorCert;
   TrustConfig trustConfig;
 };
 
@@ -59,29 +67,36 @@ BOOST_FIXTURE_TEST_SUITE(TestParamFetcher, TestParamFetcherFixture)
 BOOST_AUTO_TEST_CASE(Constructor)
 {
   algo::PublicParams m_pubParams;
-  c2.setInterestFilter(InterestFilter(attrAuthorityPrefix),
+  c2.setInterestFilter(Name(attrAuthorityPrefix).append("PUBPARAMS"),
                        [&](const ndn::InterestFilter&, const ndn::Interest& interest) {
-                         algo::MasterKey m_masterKey;
-                         algo::ABESupport::getInstance().cpInit(m_pubParams, m_masterKey);
-                         Data result;
-                         Name dataName = interest.getName();
-                         dataName.append(ABE_TYPE_CP_ABE);
-                         dataName.appendTimestamp();
-                         result.setName(dataName);
-                         result.setFreshnessPeriod(10_s);
-                         const auto& contentBuf = m_pubParams.toBuffer();
-                         result.setContent(contentBuf);
-                         m_keyChain.sign(result, signingByCertificate(authorityCert));
+                            algo::MasterKey m_masterKey;
+                            algo::ABESupport::getInstance().cpInit(m_pubParams, m_masterKey);
+                            Data result;
+                            Name dataName = interest.getName();
+                            dataName.append(ABE_TYPE_CP_ABE);
+                            dataName.appendTimestamp();
+                            result.setName(dataName);
+                            result.setFreshnessPeriod(10_s);
+                            const auto& contentBuf = m_pubParams.toBuffer();
+                            result.setContent(contentBuf);
+                            m_keyChain.sign(result, signingByCertificate(authorityCert));
 
-                         NDN_LOG_TRACE("Reply public params request.");
-                         NDN_LOG_TRACE("Pub params size: " << contentBuf.size());
+                            NDN_LOG_TRACE("Reply public params request.");
+                            NDN_LOG_TRACE("Pub params size: " << contentBuf.size());
 
-                         c2.put(result);
-                       });
+                            c2.put(result);
+                       }
+                       );
 
-  ParamFetcher paramFetcher(c1, attrAuthorityPrefix, trustConfig);
+  security::ValidatorConfig validator(c1);
+  validator.load("tests/unit-tests/trust-schema.t.conf");
+  ParamFetcher paramFetcher(c1, validator, attrAuthorityPrefix, trustConfig);
   paramFetcher.fetchPublicParams();
-  advanceClocks(time::milliseconds(10), 100);
+  advanceClocks(time::milliseconds(20), 60);
+  c1.receive(authorityCert);
+  advanceClocks(time::milliseconds(20), 60);
+  c1.receive(anchorCert);
+  advanceClocks(time::milliseconds(20), 60);
 
   BOOST_CHECK(paramFetcher.getPublicParams().m_pub != "");
   BOOST_CHECK(paramFetcher.getAbeType() == ABE_TYPE_CP_ABE);

--- a/tests/unit-tests/param-fetcher.t.cpp
+++ b/tests/unit-tests/param-fetcher.t.cpp
@@ -45,7 +45,7 @@ public:
 
     security::pib::Identity anchorId = addIdentity("/example");
     anchorCert = anchorId.getDefaultKey().getDefaultCertificate();
-    saveCertToFile(anchorCert, "tests/unit-tests/example-trust-anchor.t.cert");
+    saveCertToFile(anchorCert, "example-trust-anchor.cert");
     security::pib::Identity authorityId = addIdentity(attrAuthorityPrefix);
     addSubCertificate(attrAuthorityPrefix, anchorId);
     authorityCert = authorityId.getDefaultKey().getDefaultCertificate();
@@ -89,7 +89,7 @@ BOOST_AUTO_TEST_CASE(Constructor)
                        );
 
   security::ValidatorConfig validator(c1);
-  validator.load("tests/unit-tests/trust-schema.t.conf");
+  validator.load("trust-schema.conf");
   ParamFetcher paramFetcher(c1, validator, attrAuthorityPrefix, trustConfig);
   paramFetcher.fetchPublicParams();
   advanceClocks(time::milliseconds(20), 60);

--- a/tests/unit-tests/producer.t.cpp
+++ b/tests/unit-tests/producer.t.cpp
@@ -44,7 +44,7 @@ public:
   {
     c1.linkTo(c2);
     security::pib::Identity anchorId = addIdentity("/example");
-    saveCertToFile(anchorId.getDefaultKey().getDefaultCertificate(), "example-trust-anchor.t.cert");
+    saveCertToFile(anchorId.getDefaultKey().getDefaultCertificate(), "example-trust-anchor.cert");
 
     security::pib::Identity producerId = addIdentity("/example/producer");
     addSubCertificate("/example/producer", anchorId);
@@ -83,7 +83,7 @@ BOOST_AUTO_TEST_CASE(Constructor)
 
   advanceClocks(time::milliseconds(20), 60);
   security::ValidatorConfig validator(c1);
-  validator.load("tests/unit-tests/trust-schema.t.conf");
+  validator.load("trust-schema.conf");
   Producer producer(c1, m_keyChain, validator, producerCert, authorityCert);
   advanceClocks(time::milliseconds(10), 60);
 
@@ -93,7 +93,7 @@ BOOST_AUTO_TEST_CASE(Constructor)
 BOOST_AUTO_TEST_CASE(OnPolicyInterest)
 {
   security::ValidatorConfig validator(c1);
-  validator.load("tests/unit-tests/trust-schema.t.conf");
+  validator.load("trust-schema.conf");
   Producer producer(c1, m_keyChain, validator, producerCert, authorityCert, ownerCert);
   producer.m_paramFetcher.m_abeType = ABE_TYPE_CP_ABE;
   advanceClocks(time::milliseconds(20), 60);
@@ -151,7 +151,7 @@ BOOST_AUTO_TEST_CASE(OnPolicyInterest)
 BOOST_AUTO_TEST_CASE(OnKpPolicyInterest)
 {
   security::ValidatorConfig validator(c1);
-  validator.load("tests/unit-tests/trust-schema.t.conf");
+  validator.load("trust-schema.conf");
   Producer producer(c1, m_keyChain, validator, producerCert, authorityCert, ownerCert);
   producer.m_paramFetcher.m_abeType = ABE_TYPE_KP_ABE;
   advanceClocks(time::milliseconds(20), 60);
@@ -214,7 +214,7 @@ BOOST_AUTO_TEST_CASE(EncryptContent)
   algo::PublicParams pubParams;
   algo::MasterKey masterKey;
   security::ValidatorConfig validator(c1);
-  validator.load("tests/unit-tests/trust-schema.t.conf");
+  validator.load("trust-schema.conf");
   Producer producer(c1, m_keyChain, validator, producerCert, authorityCert);
   advanceClocks(time::milliseconds(20), 60);
   algo::ABESupport::getInstance().cpInit(pubParams, masterKey);
@@ -240,7 +240,7 @@ BOOST_AUTO_TEST_CASE(KpEncryptContent)
   algo::PublicParams pubParams;
   algo::MasterKey masterKey;
   security::ValidatorConfig validator(c1);
-  validator.load("tests/unit-tests/trust-schema.t.conf");
+  validator.load("trust-schema.conf");
   Producer producer(c1, m_keyChain, validator, producerCert, authorityCert);
   advanceClocks(time::milliseconds(20), 60);
   algo::ABESupport::getInstance().kpInit(pubParams, masterKey);

--- a/tests/unit-tests/trust-schema.conf
+++ b/tests/unit-tests/trust-schema.conf
@@ -30,5 +30,5 @@ rule
 trust-anchor
 {
   type file
-  file-name "example-trust-anchor.t.cert"
+  file-name "example-trust-anchor.cert"
 }

--- a/tests/unit-tests/trust-schema.t.conf
+++ b/tests/unit-tests/trust-schema.t.conf
@@ -1,0 +1,34 @@
+rule
+{
+  id "rule"
+  for data
+  filter
+  {
+    type name
+    name /example
+    relation is-prefix-of
+  }
+  checker
+  {
+    type customized
+    sig-type ecdsa-sha256
+    key-locator
+    {
+      type name
+      hyper-relation
+      {
+        k-regex ^(<>*)<KEY><><>?<>?$
+        k-expand \\1
+        h-relation is-prefix-of
+        p-regex ^(<>*)<>*$
+        p-expand \\1
+      }
+    }
+  }
+}
+
+trust-anchor
+{
+  type file
+  file-name "example-trust-anchor.t.cert"
+}


### PR DESCRIPTION
This PR provides partial trust schema support for NAC-ABE.

What are covered by this change: ParamFetcher, Producer, Consumer, Attribute Authority.
What are **not** covered by this change: DataOwner (and its interactions with others).

This change breaks the existing APIs by requiring a [validator](https://docs.named-data.net/ndn-cxx/current/doxygen/classndn_1_1security_1_1v2_1_1Validator.html) input in ParamFetcher, Producer and Consumer constructors.