### PR TITLE
Segmentation Support for Decryption Key

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -169,7 +169,8 @@ jobs:
           ln -sf /usr/local/opt/openssl@1.1/include/openssl /usr/local/include
           ln -sf /usr/local/opt/openssl@1.1/lib/lib* /usr/local/lib
           NO_DEPS=1 BISON="$(brew --prefix bison)/bin/bison" make
-          make test
+          # test is no longer compliable after b8f9d3c8a2620c1185ca972248f7af39c1eae68c
+          # make test
           sudo -E make install
           cd ../NAC-ABE
         env:

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -55,7 +55,8 @@ jobs:
         cd ../..
 
         NO_DEPS=1 BISON=$(which bison) make
-        make test
+        # test is no longer compliable after b8f9d3c8a2620c1185ca972248f7af39c1eae68c
+        # make test
         sudo -E make install
         cd ../NAC-ABE
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ project(nac-abe
         DESCRIPTION "NDN Name-based access control - attribute based encryption library")
 
 # flags
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 if (HAVE_TESTS)
     add_compile_definitions(HAVE_TESTS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ endif(HAVE_TESTS)
 
 # dependencies
 find_package(PkgConfig REQUIRED)
-pkg_check_modules(NDN_CXX REQUIRED libndn-cxx)
+pkg_check_modules(NDN_CXX REQUIRED libndn-cxx>=0.8.1)
 find_package(OpenSSL REQUIRED)
 
 find_library(openabe NAMES openabe REQUIRED)

--- a/README.md
+++ b/README.md
@@ -113,15 +113,8 @@ To run tests, you must have `-DHAVE_TESTS=True` when you config the project.
 To run example, you must have `-DBUILD_EXAMPLES=True` when you config the project.
 
 ```bash
-# in the build directory of NAC-ABE
-#run all the tests (including integrate test)
-ndnsec key-gen -t r /consumerPrefix1
-ndnsec key-gen /aaPrefix
-ndnsec key-gen /producerPrefix
-
-./examples/kp-aa-example &
-./examples/kp-producer-example &
-./examples/kp-consumer-example
+# in the examples directory of NAC-ABE
+bash run-examples.sh ../build
 ```
 
 ## 3 Documentation

--- a/examples/run-examples.sh
+++ b/examples/run-examples.sh
@@ -6,8 +6,10 @@
 
 if ndnsec list | grep "/example/consumer\|/example/aa\|/example/producer"
 then
-  echo "Make sure you do not have identity /example/consumer, /example/aa, /example/producer in the keychain before try again"
-  exit 1
+  echo "cleaning example identities"
+  ndnsec delete /example/consumer
+  ndnsec delete /example/aa
+  ndnsec delete /example/producer
 fi
 
 export NDN_LOG=*=INFO

--- a/src/attribute-authority.hpp
+++ b/src/attribute-authority.hpp
@@ -29,6 +29,9 @@
 #include <list>
 #include <map>
 
+#include <ndn-cxx/util/segmenter.hpp>
+#include <ndn-cxx/security/signing-helpers.hpp>
+
 namespace ndn {
 namespace nacabe {
 
@@ -56,6 +59,8 @@ protected:
   Face& m_face;
   KeyChain& m_keyChain;
   TrustConfig m_trustConfig;
+  std::map<Name, std::vector<std::shared_ptr<Data>>> m_segmentMap;
+  util::Segmenter m_segmenter{m_keyChain, signingByCertificate(m_cert)};
 
 PUBLIC_WITH_TESTS_ELSE_PROTECTED:
   AbeType m_abeType;

--- a/src/attribute-authority.hpp
+++ b/src/attribute-authority.hpp
@@ -39,7 +39,8 @@ class AttributeAuthority : noncopyable
 {
 protected:
   AttributeAuthority(const security::Certificate& identityCert, Face& m_face,
-                     KeyChain& keyChain, const AbeType& abeType);
+                     KeyChain& keyChain, const AbeType& abeType,
+                     size_t maxSegmentSize = 1500);
 
   virtual
   ~AttributeAuthority();
@@ -59,6 +60,7 @@ protected:
   Face& m_face;
   KeyChain& m_keyChain;
   TrustConfig m_trustConfig;
+  ssize_t m_maxSegmentSize;
   std::map<Name, std::vector<std::shared_ptr<Data>>> m_segmentMap;
   util::Segmenter m_segmenter{m_keyChain, signingByCertificate(m_cert)};
 
@@ -109,7 +111,7 @@ PUBLIC_WITH_TESTS_ELSE_PRIVATE:
 class KpAttributeAuthority: public AttributeAuthority
 {
 public:
-  KpAttributeAuthority(const security::Certificate& identityCert, Face& m_face, KeyChain& keyChain);
+  KpAttributeAuthority(const security::Certificate& identityCert, Face& m_face, KeyChain& keyChain, size_t maxSegmentSize = 1500);
 
   /**
    * @brief Add a new policy <decryptor name, decryptor attributes> into the state.

--- a/src/trust-config.cpp
+++ b/src/trust-config.cpp
@@ -68,7 +68,7 @@ TrustConfig::addOrUpdateCertificate(const security::Certificate& certificate)
   }
 }
 
-optional<security::Certificate>
+std::optional<security::Certificate>
 TrustConfig::findCertificate(const Name& identityName) const
 {
   auto search = m_knownIdentities.find(identityName);
@@ -76,7 +76,7 @@ TrustConfig::findCertificate(const Name& identityName) const
     return make_optional(search->second);
   }
   else {
-    return nullopt;
+    return std::nullopt;
   }
 }
 

--- a/src/trust-config.cpp
+++ b/src/trust-config.cpp
@@ -73,7 +73,7 @@ TrustConfig::findCertificate(const Name& identityName) const
 {
   auto search = m_knownIdentities.find(identityName);
   if (search != m_knownIdentities.end()) {
-    return make_optional(search->second);
+    return search->second;
   }
   else {
     return std::nullopt;

--- a/src/trust-config.hpp
+++ b/src/trust-config.hpp
@@ -37,7 +37,7 @@ public:
   void
   addOrUpdateCertificate(const security::Certificate& certificate);
 
-  optional<security::Certificate>
+  std::optional<security::Certificate>
   findCertificate(const Name& identityName) const;
 
 private:


### PR DESCRIPTION
This PR adds segmentation supports for the decryption key, since in KP-ABE scenario, the decryption size can go larger than the network MTU.

The maximum segment size is by default 1500 bytes, but configurable through the AttributeAuthority constructor.
This PR also updates the example script and the README text regarding the examples.