### PR TITLE
refactor consumer certificate fetching

### DIFF
--- a/examples/kp-producer-example.cpp
+++ b/examples/kp-producer-example.cpp
@@ -29,13 +29,11 @@
 
 namespace examples {
 
-ndn::KeyChain m_keyChain;
-ndn::security::Certificate m_cert = m_keyChain.getPib().getIdentity("/example/producer").getDefaultKey().getDefaultCertificate();
 class Producer
 {
 public:
   Producer()
-    : m_producerCert(m_cert)
+    : m_producerCert(m_keyChain.getPib().getIdentity("/example/producer").getDefaultKey().getDefaultCertificate())
     , m_producer(m_face, m_keyChain, m_validator, m_producerCert,
                  m_keyChain.getPib().getIdentity("/example/aa").getDefaultKey().getDefaultCertificate())
   {
@@ -72,8 +70,8 @@ public:
       [=] (const auto&, const auto& interest) {
         std::cout << ">> I: " << interest << std::endl;
         // for own certificate
-        if (interest.getName().isPrefixOf(m_cert.getName())) {
-          m_face.put(m_cert);
+        if (interest.getName().isPrefixOf(m_producerCert.getName())) {
+          m_face.put(m_producerCert);
         }
         // for content data segments
         putSegments(interest, contentData);
@@ -96,6 +94,7 @@ public:
 
 private:
   ndn::Face m_face;
+  ndn::KeyChain m_keyChain;
   ndn::ValidatorConfig m_validator{m_face};
   ndn::security::Certificate m_producerCert;
   ndn::nacabe::Producer m_producer;

--- a/examples/run-examples.sh
+++ b/examples/run-examples.sh
@@ -4,11 +4,12 @@
 # If you would like to try on a normal user account, make sure that identity /consumerPrefix1, /aaPrefix, /producerPrefix
 # are not used, as these keys will be deleted.
 
-if ndnsec list | grep "/example/consumer\|/example/aa\|/example/producer"
+if ndnsec list | grep "/example"
 then
   echo "cleaning example identities"
-  ndnsec delete /example/consumer
+  ndnsec delete /example
   ndnsec delete /example/aa
+  ndnsec delete /example/consumer
   ndnsec delete /example/producer
 fi
 
@@ -26,6 +27,9 @@ ndnsec sign-req /example/producer | ndnsec cert-gen -s /example -i example | ndn
 ndnsec key-gen -t r /example/consumer > /dev/null
 ndnsec sign-req /example/consumer | ndnsec cert-gen -s /example -i example | ndnsec cert-install -
 
+# cp example-trust-anchor.cert $1/examples/example-trust-anchor.cert
+# cp trust-schema.conf $1/examples/trust-schema.conf
+nfdc cs erase /example
 $1/examples/kp-aa-example &
 aa_pid=$!
 sleep 1
@@ -39,6 +43,7 @@ exit_val=$?
 kill $aa_pid
 kill $pro_pid
 
+ndnsec delete /example
 ndnsec delete /example/consumer
 ndnsec delete /example/aa
 ndnsec delete /example/producer

--- a/src/attribute-authority.hpp
+++ b/src/attribute-authority.hpp
@@ -39,8 +39,8 @@ class AttributeAuthority : noncopyable
 {
 protected:
   AttributeAuthority(const security::Certificate& identityCert, Face& m_face,
-                     KeyChain& keyChain, const AbeType& abeType,
-                     size_t maxSegmentSize = 1500);
+                     security::Validator& validator, KeyChain& keyChain,
+                     const AbeType& abeType, size_t maxSegmentSize = 1500);
 
   virtual
   ~AttributeAuthority();
@@ -49,6 +49,9 @@ protected:
   getPrivateKey(Name identityName) = 0;
 
 private:
+  SPtrVector<Data>
+  generateDecryptionKeySegments(const Name& objName, const security::Certificate& cert);
+
   void
   onDecryptionKeyRequest(const Interest& interest);
 
@@ -59,6 +62,7 @@ protected:
   security::Certificate m_cert;
   Face& m_face;
   KeyChain& m_keyChain;
+  security::Validator& m_validator;
   TrustConfig m_trustConfig;
   ssize_t m_maxSegmentSize;
   std::map<Name, SPtrVector<ndn::Data>> m_segmentMap;
@@ -77,7 +81,8 @@ private:
 class CpAttributeAuthority: public AttributeAuthority
 {
 public:
-  CpAttributeAuthority(const security::Certificate& identityCert, Face& m_face, KeyChain& keyChain);
+  CpAttributeAuthority(const security::Certificate& identityCert, Face& m_face, 
+                       security::Validator& validator, KeyChain& keyChain);
 
   /**
    * @brief Add a new policy <decryptor name, decryptor attributes> into the state.
@@ -111,7 +116,9 @@ PUBLIC_WITH_TESTS_ELSE_PRIVATE:
 class KpAttributeAuthority: public AttributeAuthority
 {
 public:
-  KpAttributeAuthority(const security::Certificate& identityCert, Face& m_face, KeyChain& keyChain, size_t maxSegmentSize = 1500);
+  KpAttributeAuthority(const security::Certificate& identityCert, Face& m_face,
+                       security::Validator& validator, KeyChain& keyChain,
+                       size_t maxSegmentSize = 1500);
 
   /**
    * @brief Add a new policy <decryptor name, decryptor attributes> into the state.

--- a/src/param-fetcher.cpp
+++ b/src/param-fetcher.cpp
@@ -57,7 +57,6 @@ void
 ParamFetcher::onAttributePubParams(const Data& pubParamData)
 {
   NDN_LOG_INFO("[onAttributePubParams()] Get public parameters");
-  // auto optionalAAKey = m_trustConfig.findCertificate(m_attrAuthorityPrefix);
 
   m_validator.validate(pubParamData,
     [this, pubParamData] (const Data& data) {

--- a/src/producer.hpp
+++ b/src/producer.hpp
@@ -195,7 +195,7 @@ private:
   KeyChain& m_keyChain;
   security::Validator& m_validator;
   Name m_attrAuthorityPrefix;
-  Name m_dataOwnerPrefix;
+  Name m_dataOwnerKeyName;
   TrustConfig m_trustConfig;
   ScopedRegisteredPrefixHandle m_registeredPrefix;
 

--- a/src/trust-config.hpp
+++ b/src/trust-config.hpp
@@ -27,10 +27,11 @@
 
 namespace ndn {
 namespace nacabe {
-
 class TrustConfig
 {
 public:
+  using FetchCertSuccessCb = std::function<void(const security::Certificate&)>;
+  using FetchCertFailureCb = std::function<void(const std::string)>;
   void
   load(const std::string& fileName);
 
@@ -38,14 +39,20 @@ public:
   addOrUpdateCertificate(const security::Certificate& certificate);
 
   std::optional<security::Certificate>
-  findCertificate(const Name& identityName) const;
+  findCertificateFromLocal(const Name& KeyName) const;
+
+  void
+  findCertificateFromNetwork(Face& face, security::Validator& validator,
+                             const Name& KeyName,
+                             const FetchCertSuccessCb& onSuccess,
+                             const FetchCertFailureCb& onFailure);
 
 private:
   void
   parse(const JsonSection& jsonConfig);
 
 private:
-  std::map<Name, security::Certificate> m_knownIdentities;
+  std::map<Name, security::Certificate> m_knownKeys;
 };
 
 } // namespace nacabe

--- a/tests/unit-tests/integrated-test.t.cpp
+++ b/tests/unit-tests/integrated-test.t.cpp
@@ -107,7 +107,9 @@ BOOST_AUTO_TEST_CASE(Cp)
 {
   // set up AA
   NDN_LOG_INFO("Create Attribute Authority. AA prefix: " << aaCert.getIdentity());
-  CpAttributeAuthority aa(aaCert, aaFace, m_keyChain);
+  security::ValidatorConfig validator(aaFace);
+  validator.load("trust-schema.conf");
+  CpAttributeAuthority aa(aaCert, aaFace, validator, m_keyChain);
   advanceClocks(time::milliseconds(20), 60);
 
   // define attr list for consumer rights
@@ -158,7 +160,7 @@ BOOST_AUTO_TEST_CASE(Cp)
   BOOST_CHECK(producer.m_paramFetcher.getPublicParams().m_pub != "");
 
   // set up data owner
-  NDN_LOG_INFO("Create Data Owner. Data Owner prefix:"<<dataOwnerCert.getIdentity());
+  NDN_LOG_INFO("Create Data Owner. Data Owner prefix:" << dataOwnerCert.getIdentity());
   DataOwner dataOwner(dataOwnerCert, dataOwnerFace, m_keyChain);
   advanceClocks(time::milliseconds(20), 60);
 
@@ -169,16 +171,17 @@ BOOST_AUTO_TEST_CASE(Cp)
 
   bool isPolicySet = false;
   dataOwner.commandProducerPolicy(producerCert.getIdentity(), dataName, policy,
-                                   [&] (const Data& response) {
-                                     NDN_LOG_DEBUG("on policy set data callback");
-                                     isPolicySet = true;
-                                     BOOST_CHECK_EQUAL(readString(response.getContent()), "success");
-                                     auto policyFound = producer.findMatchedPolicy(dataName);
-                                     BOOST_CHECK(policyFound == policy);
-                                   },
-                                   [] (const std::string&) {
-                                     BOOST_CHECK(false);
-                                   });
+    [&] (const Data& response) {
+      NDN_LOG_DEBUG("on policy set data callback");
+      isPolicySet = true;
+      BOOST_CHECK_EQUAL(readString(response.getContent()), "success");
+      auto policyFound = producer.findMatchedPolicy(dataName);
+      BOOST_CHECK(policyFound == policy);
+    },
+    [] (const std::string&) {
+      BOOST_CHECK(false);
+    }
+  );
 
   NDN_LOG_DEBUG("Before policy set");
   advanceClocks(time::milliseconds(20), 60);
@@ -260,7 +263,9 @@ BOOST_AUTO_TEST_CASE(Kp)
 {
   // set up AA
   NDN_LOG_INFO("Create Attribute Authority. AA prefix: " << aaCert.getIdentity());
-  KpAttributeAuthority aa(aaCert, aaFace, m_keyChain);
+  security::ValidatorConfig validator(aaFace);
+  validator.load("trust-schema.conf");
+  KpAttributeAuthority aa(aaCert, aaFace, validator, m_keyChain);
   advanceClocks(time::milliseconds(20), 60);
 
   // define attr list for consumer rights
@@ -408,7 +413,9 @@ BOOST_AUTO_TEST_CASE(KpCache)
 {
   // set up AA
   NDN_LOG_INFO("Create Attribute Authority. AA prefix: " << aaCert.getIdentity());
-  KpAttributeAuthority aa(aaCert, aaFace, m_keyChain);
+  security::ValidatorConfig validator(aaFace);
+  validator.load("trust-schema.conf");
+  KpAttributeAuthority aa(aaCert, aaFace, validator, m_keyChain);
   advanceClocks(time::milliseconds(20), 60);
 
   // define attr list for consumer rights


### PR DESCRIPTION
This PR adds consumer fetching to TrustConfig. If corresponding consumer certificate cannot be found in configuration file, attribute authority expresses Interest to fetch from the network and validates it. It also cleans some redundant code in library.

This PR breaks the current attribute authority by requiring a validator input.